### PR TITLE
支持直接以docker-compose up启动开发环境。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 version: '3'
 services:
     laravel.test:
+        container_name: laravel.test
         build:
             context: ./vendor/laravel/sail/runtimes/8.0
             dockerfile: Dockerfile
@@ -16,7 +17,9 @@ services:
         volumes:
             - '.:/var/www/html'
         networks:
-            - sail
+            sail:
+              aliases:
+                  - weibo.test
         depends_on:
             - mysql
             - redis
@@ -30,19 +33,21 @@ services:
     #     depends_on:
     #         - laravel.test
     mysql:
+        container_name: weibo.mysql
         image: 'mysql:8.0'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
             MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
             MYSQL_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         volumes:
             - 'sailmysql:/var/lib/mysql'
         networks:
-            - sail
+            sail:
+              aliases:
+                  - weibo.mysql
     redis:
         image: 'redis:alpine'
         ports:
@@ -50,7 +55,9 @@ services:
         volumes:
             - 'sailredis:/data'
         networks:
-            - sail
+            sail:
+              aliases:
+                    - weibo.redis
     # memcached:
     #     image: 'memcached:alpine'
     #     ports:
@@ -58,12 +65,15 @@ services:
     #     networks:
     #         - sail
     mailhog:
+        container_name: weibo.mailhog
         image: 'mailhog/mailhog:latest'
         ports:
             - 1025:1025
             - 8025:8025
         networks:
-            - sail
+            sail:
+              aliases:
+                    - weibo.mailhog
 networks:
     sail:
         driver: bridge


### PR DESCRIPTION
在有docker的情况下，这应该是最快启动开发环境的方法。

## 1.  安装PHP依赖
```
docker-compose run laravel.test composer install -vvv
```

## 2. 设置host参数

在创建.env以后，
```
cp .env.example .env
```

设置各自的host即可，如

```
...
DB_HOST=weibo.mysql
...

REDIS_HOST=weibo.redis

...
MAIL_HOST=weibo.mailhog
...
```

## 3. 其它参数
```
APP_PORT=80
FORWARD_DB_PORT=3306

// 在Mac, 可通过`id`命令查询下例值

WWWGROUP=501
WWWUSER=20

```

## 4. 启动服务

```
docker-compose up 
```
